### PR TITLE
Added specs and updated default config logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 bower_components/
 node_modules/
 coverage/

--- a/src/resource.js
+++ b/src/resource.js
@@ -6,8 +6,12 @@ eResource.provider('resource-api', function eResourceProvider(){
 
   var defaultConfig = {};
 
+  /*
+    Supported config:
+      headers
+   */
   this.defaultConfig = function(config) {
-    defaultConfig = config;
+    defaultConfig = angular.copy(config);
   };
 
   this.$get = [
@@ -106,6 +110,7 @@ eResource.provider('resource-api', function eResourceProvider(){
         },
         defaults: {
           cache: false,
+          headers: defaultConfig.headers || {},
           transformPath: [],
           transformRequest: angular.copy($http.defaults.transformRequest),
           transformResponse: angular.copy($http.defaults.transformResponse),
@@ -133,13 +138,18 @@ eResource.provider('resource-api', function eResourceProvider(){
       }
       function initConfig(config) {
         var original = angular.extend({}, config);
-        config = angular.extend({}, defaultConfig, original, {
-          transformPath: original.transformPath ? angular.copy(original.transformPath) : [],
-          transformRequest: original.transformRequest ? angular.copy(original.transformRequest) : [],
-          transformResponse: original.transformResponse ? angular.copy(original.transformResponse) : [],
-          cache: false,
-          $original: original
-        });
+        config = angular.extend({
+            headers: api.defaults.headers
+          },
+          original,
+          {
+            transformPath: original.transformPath ? angular.copy(original.transformPath) : [],
+            transformRequest: original.transformRequest ? angular.copy(original.transformRequest) : [],
+            transformResponse: original.transformResponse ? angular.copy(original.transformResponse) : [],
+            cache: false,
+            $original: original
+          }
+        );
         config.transformPath.push.apply(config.transformPath, angular.copy(api.defaults.transformPath));
         config.transformRequest.push.apply(config.transformRequest, angular.copy(api.defaults.transformRequest));
         config.transformResponse.unshift.apply(config.transformResponse, angular.copy(api.defaults.transformResponse));

--- a/test/specs/resource-api.spec.js
+++ b/test/specs/resource-api.spec.js
@@ -1,7 +1,16 @@
 'use strict';
 
 describe('epixa-resource', function() {
-  beforeEach(module('epixa-resource'));
+  beforeEach(function() {
+    module('epixa-resource', ['resource-apiProvider', function(resourceApiProvider){
+      resourceApiProvider.defaultConfig({
+        headers: {
+          Accept: 'application/json.v2'
+        }
+      });
+    }])
+  });
+
 
   var $rootScope, $httpBackend, fooData;
   beforeEach(inject(function($injector) {
@@ -43,6 +52,41 @@ describe('epixa-resource', function() {
     beforeEach(inject(function($injector) {
       api = $injector.get('resource-api');
     }));
+
+    describe('configuration', function () {
+      describe('headers', function() {
+        it('should use default configuration if set', function () {
+          $httpBackend.expectGET('/config-test/1', function(headers) {
+            return headers['Accept'] === 'application/json.v2';
+          }).respond({});
+          api.get('/config-test/1', {});
+          $httpBackend.flush();
+        });
+
+        it('should use overridden configuration, if available', function () {
+          $httpBackend.expectGET('/config-test/1', function(headers) {
+            return headers['Accept'] === 'application/json.overridden';
+          }).respond({});
+          api.get('/config-test/1', {
+            headers: {
+              Accept: 'application/json.overridden'
+            }
+          });
+          $httpBackend.flush();
+        });
+
+        it('should allow default configuration to change', function() {
+          api.defaults.headers = {
+            Accept: 'application/json.overridden2'
+          };
+          $httpBackend.expectGET('/config-test/1', function(headers) {
+            return headers['Accept'] === 'application/json.overridden2';
+          }).respond({});
+          api.get('/config-test/1');
+          $httpBackend.flush();
+        });
+      });
+    });
 
     describe('.reload()', function() {
       var resource, collection, collectionConfig;


### PR DESCRIPTION
Added specs and updated default config to leverages . Limited support to headers.

```javascript
angular.module('testApp', ['epixa-resource']).config(['resource-apiProvider', function(resourceApiProvider) {
    resourceApiProvider.defaultConfig({
        headers: {
            Accept: 'application/json.v2'
        }
    });
}])
```

